### PR TITLE
Add Summary of Breaking Changes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "name": "Current File",
             "request": "launch",
             "mainClass": "${file}",
-            "args": "-new target/test-classes/petstore_v2_1.json -old target/test-classes/petstore_v2_2.json -output-mode slack"
+            "args": "-new target/test-classes/petstore_v2_1.json -old target/test-classes/petstore_v2_2.json -breaking_summary -output-mode slack"
         },
         {
             "type": "java",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "name": "Current File",
             "request": "launch",
             "mainClass": "${file}",
-            "args": "-new sample/current_service.json -old sample/previous_service.json -output-mode slack_webhook"
+            "args": "-new target/test-classes/petstore_v2_1.json -old target/test-classes/petstore_v2_2.json -output-mode slack"
         },
         {
             "type": "java",

--- a/src/main/java/com/deepoove/swagger/diff/SwaggerDiff.java
+++ b/src/main/java/com/deepoove/swagger/diff/SwaggerDiff.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.deepoove.swagger.diff.compare.BreakingChangesCheckUtil;
 import com.deepoove.swagger.diff.compare.SpecificationDiff;
 import com.deepoove.swagger.diff.model.ChangedEndpoint;
 import com.deepoove.swagger.diff.model.Endpoint;
@@ -156,5 +157,13 @@ public class SwaggerDiff {
 
     public String getNewVersion() {
         return newSpecSwagger.getInfo().getVersion();
+    }
+
+    public boolean hasSameEndpoints() {
+        return this.newEndpoints.isEmpty() && this.missingEndpoints.isEmpty() && this.changedEndpoints.isEmpty();
+    }
+
+    public boolean hasBreakingChanges() {
+        return BreakingChangesCheckUtil.hasBreakingChanges(this);
     }
 }

--- a/src/main/java/com/deepoove/swagger/diff/SwaggerDiff.java
+++ b/src/main/java/com/deepoove/swagger/diff/SwaggerDiff.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 
 import com.deepoove.swagger.diff.compare.BreakingChangesCheckUtil;
 import com.deepoove.swagger.diff.compare.SpecificationDiff;
+import com.deepoove.swagger.diff.model.BreakingDiff;
 import com.deepoove.swagger.diff.model.ChangedEndpoint;
 import com.deepoove.swagger.diff.model.Endpoint;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -29,6 +30,8 @@ public class SwaggerDiff {
     private List<Endpoint> newEndpoints;
     private List<Endpoint> missingEndpoints;
     private List<ChangedEndpoint> changedEndpoints;
+
+    private BreakingDiff breakingChanges;
 
     /**
      * compare two swagger 1.x doc
@@ -136,6 +139,7 @@ public class SwaggerDiff {
         this.newEndpoints = diff.getNewEndpoints();
         this.missingEndpoints = diff.getMissingEndpoints();
         this.changedEndpoints = diff.getChangedEndpoints();
+        this.breakingChanges = BreakingChangesCheckUtil.findAllBreakingChanges(this);
         return this;
     }
 
@@ -160,10 +164,14 @@ public class SwaggerDiff {
     }
 
     public boolean hasSameEndpoints() {
-        return this.newEndpoints.isEmpty() && this.missingEndpoints.isEmpty() && this.changedEndpoints.isEmpty();
+        return newEndpoints.isEmpty() && missingEndpoints.isEmpty() && changedEndpoints.isEmpty();
+    }
+
+    public BreakingDiff getBreakingChanges() {
+        return breakingChanges;
     }
 
     public boolean hasBreakingChanges() {
-        return BreakingChangesCheckUtil.hasBreakingChanges(this);
+        return breakingChanges.isBreaking();
     }
 }

--- a/src/main/java/com/deepoove/swagger/diff/cli/CLI.java
+++ b/src/main/java/com/deepoove/swagger/diff/cli/CLI.java
@@ -53,6 +53,9 @@ public class CLI {
     @Parameter(names = "-branch_title", description = "Add branch title to the output")
     private String branchTitle;
 
+    @Parameter(names = "-breaking_summary", description = "Add a summary of the breaking changes")
+    private boolean breakingSummary;
+
     public static void main(String[] args) {
         CLI cli = new CLI();
         JCommander jCommander = JCommander.newBuilder()
@@ -76,7 +79,7 @@ public class CLI {
         SwaggerDiff diff = SwaggerDiff.SWAGGER_VERSION_V2.equals(version)
                 ? SwaggerDiff.compareV2(oldSpec, newSpec) : SwaggerDiff.compareV1(oldSpec, newSpec);
 
-        String render = getRender(outputMode).render(diff, new RenderOptions(pingHere, branchTitle));
+        String render = getRender(outputMode).render(diff, new RenderOptions(pingHere, branchTitle, breakingSummary));
         JCommander.getConsole().println(render);
     }
 

--- a/src/main/java/com/deepoove/swagger/diff/compare/BreakingChangesCheckUtil.java
+++ b/src/main/java/com/deepoove/swagger/diff/compare/BreakingChangesCheckUtil.java
@@ -1,0 +1,82 @@
+package com.deepoove.swagger.diff.compare;
+
+import com.deepoove.swagger.diff.SwaggerDiff;
+import com.deepoove.swagger.diff.model.ChangedEndpoint;
+import com.deepoove.swagger.diff.model.ChangedOperation;
+import com.deepoove.swagger.diff.model.ChangedParameter;
+import com.deepoove.swagger.diff.model.ElProperty;
+
+import io.swagger.models.HttpMethod;
+import io.swagger.models.parameters.Parameter;
+
+public class BreakingChangesCheckUtil {
+
+    public static boolean hasBreakingChanges(SwaggerDiff swaggerDiff) {
+        if (!swaggerDiff.getMissingEndpoints().isEmpty()) {
+            return true;
+        }
+        for (ChangedEndpoint changedEndpoint : swaggerDiff.getChangedEndpoints()) {
+            if (hasBreakingChanges(changedEndpoint)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean hasBreakingChanges(ChangedEndpoint changedEndpoint) {
+        if (!changedEndpoint.getMissingOperations().isEmpty()) {
+            return true;
+        }
+        for (HttpMethod httpMethod : changedEndpoint.getChangedOperations().keySet()) {
+            ChangedOperation changedOperation = changedEndpoint.getChangedOperations().get(httpMethod);
+            if (hasBreakingChanges(changedOperation)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean hasBreakingChanges(ChangedOperation changedOperation) {
+        // Props (Return Type)
+        if (!changedOperation.getMissingProps().isEmpty()) {
+            return true;
+        }
+        for (ElProperty elProperty : changedOperation.getChangedProps()) {
+            if (elProperty.isTypeChange() || elProperty.isRemovedEnums()) {
+                return true;
+            }
+        }
+
+        // Params
+        for (Parameter parameter : changedOperation.getAddParameters()) {
+            if (parameter.getRequired() && !parameter.getAllowEmptyValue()) {
+                return true;
+            }
+        }
+        for (ChangedParameter changedParameter : changedOperation.getChangedParameter()) {
+            Parameter leftParameter = changedParameter.getLeftParameter();
+            Parameter rightParameter = changedParameter.getRightParameter();
+            if (!leftParameter.getRequired() && rightParameter.getRequired()) {
+                return true;
+            }
+            if (leftParameter.getRequired() &&
+                    rightParameter.getRequired() &&
+                    leftParameter.getAllowEmptyValue() &&
+                    !rightParameter.getAllowEmptyValue()) {
+                return true;
+            }
+        }
+
+        // Consumes
+        if (!changedOperation.getMissingConsumes().isEmpty()) {
+            return true;
+        }
+
+        // Produces
+        if (!changedOperation.getMissingProduces().isEmpty()) {
+            return true;
+        }
+        return false;
+    }
+    
+}

--- a/src/main/java/com/deepoove/swagger/diff/model/BreakingDiff.java
+++ b/src/main/java/com/deepoove/swagger/diff/model/BreakingDiff.java
@@ -1,0 +1,36 @@
+package com.deepoove.swagger.diff.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BreakingDiff {
+
+    private List<ChangedEndpoint> changedEndpoints;
+    private List<Endpoint> missingEndpoints;
+
+    public BreakingDiff() {
+        this.changedEndpoints = new ArrayList<>();
+        this.missingEndpoints = new ArrayList<>();
+    }
+
+    public List<Endpoint> getMissingEndpoints() {
+        return missingEndpoints;
+    }
+
+    public void setMissingEndpoints(List<Endpoint> missingEndpoints) {
+        this.missingEndpoints = missingEndpoints;
+    }
+
+    public List<ChangedEndpoint> getChangedEndpoints() {
+        return changedEndpoints;
+    }
+
+    public void setChangedEndpoints(List<ChangedEndpoint> changedEndpoints) {
+        this.changedEndpoints = changedEndpoints;
+    }
+
+    public boolean isBreaking() {
+        return !this.missingEndpoints.isEmpty() || !this.changedEndpoints.isEmpty();
+    }
+    
+}

--- a/src/main/java/com/deepoove/swagger/diff/output/RenderOptions.java
+++ b/src/main/java/com/deepoove/swagger/diff/output/RenderOptions.java
@@ -6,11 +6,14 @@ public class RenderOptions {
 
     private String branchName = null;
 
+    private boolean breakingSummary = false;
+
     public RenderOptions() {}
 
-    public RenderOptions(boolean pingHere, String branchName) {
+    public RenderOptions(boolean pingHere, String branchName, boolean breakingSummary) {
         this.pingHere = pingHere;
         this.branchName = branchName;
+        this.breakingSummary = breakingSummary;
     }
 
     public boolean isPingHere() {
@@ -19,5 +22,9 @@ public class RenderOptions {
 
     public String getBranchName() {
         return branchName;
+    }
+
+    public boolean isBreakingSummary() {
+        return breakingSummary;
     }
 }

--- a/src/main/java/com/deepoove/swagger/diff/output/SlackRender.java
+++ b/src/main/java/com/deepoove/swagger/diff/output/SlackRender.java
@@ -30,7 +30,7 @@ public class SlackRender implements Render {
 
     @Override
     public String render(SwaggerDiff diff, RenderOptions options) {
-        if (hasNoChanges(diff)) {
+        if (diff.hasSameEndpoints()) {
             return NO_CHANGES_RENDER;
         }
 
@@ -63,10 +63,6 @@ public class SlackRender implements Render {
         appendChangedHeader(sb);
         appendChangedBody(sb, ol_changed);
         return sb.toString();
-    }
-
-    protected boolean hasNoChanges(SwaggerDiff diff) {
-        return diff.getNewEndpoints().isEmpty() && diff.getMissingEndpoints().isEmpty() && diff.getChangedEndpoints().isEmpty();
     }
 
     private void appendPing(StringBuffer sb) {

--- a/src/main/java/com/deepoove/swagger/diff/output/SlackRender.java
+++ b/src/main/java/com/deepoove/swagger/diff/output/SlackRender.java
@@ -45,17 +45,18 @@ public class SlackRender implements Render {
         String ol_breakingNewEndpoint = "";
         String ol_breakingMissingEndpoint = ol_missingEndpoint(breakingDiff.getMissingEndpoints());
         String ol_breakingChangedEndpoint = ol_changed(breakingDiff.getChangedEndpoints());
+        boolean hasBreakingChanges = !ol_breakingMissingEndpoint.isEmpty() || !ol_breakingChangedEndpoint.isEmpty();
 
-        String slackMarkdown = renderSlackMarkdown(options.isPingHere(), options.getBranchName(), options.isBreakingSummary(), diff.getOldVersion(), diff.getNewVersion(),
+        String slackMarkdown = renderSlackMarkdown(options.isPingHere(), options.getBranchName(), options.isBreakingSummary(), hasBreakingChanges, diff.getOldVersion(), diff.getNewVersion(),
                 ol_newEndpoint, ol_missingEndpoint, ol_changed, ol_breakingNewEndpoint, ol_breakingMissingEndpoint, ol_breakingChangedEndpoint);
         return slackMarkdown;
     }
 
-    public String renderSlackMarkdown(boolean isPingHere, String branchName, boolean isBreakingSummary, String oldVersion, String newVersion,
+    public String renderSlackMarkdown(boolean isPingHere, String branchName, boolean isBreakingSummary, boolean hasBreakingChanges, String oldVersion, String newVersion,
                 String ol_new, String ol_miss, String ol_changed, String ol_breakingNewEndpoint, String ol_breakingMissingEndpoint, String ol_breakingChangedEndpoint) {
         StringBuffer sb = new StringBuffer();
         appendMainHeader(sb, isPingHere, branchName, oldVersion, newVersion);
-        if (isBreakingSummary) {
+        if (isBreakingSummary && hasBreakingChanges) {
             appendBreakingChangesHeader(sb);
             appendBreakingChangesBody(sb, ol_breakingNewEndpoint, ol_breakingMissingEndpoint, ol_breakingChangedEndpoint);
             appendBreakingChangesFooter(sb);

--- a/src/main/java/com/deepoove/swagger/diff/output/SlackWebhookRender.java
+++ b/src/main/java/com/deepoove/swagger/diff/output/SlackWebhookRender.java
@@ -9,7 +9,7 @@ public class SlackWebhookRender extends SlackRender {
 
     @Override
     public String render(SwaggerDiff diff, RenderOptions options) {
-        if (hasNoChanges(diff)) {
+        if (diff.hasSameEndpoints()) {
             return NO_CHANGES_RENDER;
         }
         String slackMarkdown = super.render(diff, options);


### PR DESCRIPTION
Added support to compile a list of changes that could break existing integrations.  Added new CLI option -breaking_summary that will add a summary of the breaking changes prior to rendering the full list of changes.